### PR TITLE
TrueNAS SMB to ZFS Migration Script

### DIFF
--- a/script/TrueNAS SMB to ZFS Migration Script
+++ b/script/TrueNAS SMB to ZFS Migration Script
@@ -1,0 +1,266 @@
+#!/bin/bash
+##########################################################################################
+# ----------------------------------------------------------------------------------------
+# Holstein IT-Solutions Inh. Benedict Schultz
+# Copyright (C) 2025 Benedict Schultz
+# Autoren: Marek Slodkowski, Michael Bielicki
+#
+# Dieses Programm ist freie Software: Sie können es unter den Bedingungen der
+# Affero General Public License (AGPL), Version 3, die mit diesem Programm
+# verteilt wird, weiterverbreiten und/oder ändern.
+#
+# Dieses Programm wird in der Hoffnung, dass es nützlich ist, aber OHNE JEDE
+# GARANTIE, sogar ohne die stillschweigende Garantie der MARKTGÄNGIGKEIT oder
+# DER EIGNUNG FÜR EINEN BESTIMMTEN ZWECK, verteilt. Weitere Details finden Sie
+# in der Affero General Public License, Version 3.
+#
+# Sie sollten eine Kopie der Affero General Public License zusammen mit diesem
+# Programm erhalten haben. Wenn nicht, siehe <http://www.gnu.org/licenses/agpl-3.0.html>.
+#
+# ----------------------------------------------------------------------------------------
+# TrueNAS Benutzer-Migration von SMB zu ZFS
+# ----------------------------------------------------------------------------------------
+#
+# Dieses Skript migriert Benutzerverzeichnisse vom SMB-Mount zu einem ZFS-Pool.
+# - Erstellt ZFS-Datasets mit Quotas
+# - Kopiert Daten mit rsync
+# - Unterstützt Dry-Run-Modus
+# - Ermöglicht Ausschluss einzelner Benutzer
+# - Setzt NFSv4 ACLs korrekt (per UID)
+# - Sendet optional einen E-Mail-Report
+##########################################################################################
+
+### === KONFIGURATION ===
+
+MAIN_PATH="/mnt"                                   # Basis-Pfad für ZFS-Mounts
+MAIN_POOL="tank"                                   # ZFS-Pool-Name
+MAIN_DATASET="userfiles"                           # Haupt-Dataset für Benutzerdaten
+SOURCE_MOUNT="/mnt/oldhomes"                       # Quelle: gemountetes SMB-Share
+QUOTA="1G"                                         # Speicherbegrenzung je Benutzer
+LOGFILE="./migration.log"                          # Logdatei zur Protokollierung
+MAILTO=                                            # Optional: E-Mail-Adresse für Bericht (leer = deaktiviert)
+AD_DOMAIN="HITS"                                   # Active Directory-Domäne für Benutzerauflösung
+
+# Benutzer, die ausgelassen werden sollen (kommagetrennt, keine Leerzeichen)
+SKIP_USERS="test,guest,admin"
+
+# Berechtigungen für NFSv4 ACL (lesen, schreiben, ausführen, etc.)
+NFS4_ACL_STRING="rwxpDdaARWcCos:fd:allow"         
+
+# ----------------------------------------------------------------------------------------
+# NFSv4 ACL String (kann angepasst werden)
+# ----------------------------------------------------------------------------------------
+# Der folgende ACL-String wird für jeden Benutzer, der in ein ZFS-Dataset
+# migriert wird, auf das Zielverzeichnis angewendet. Der String definiert
+# die Berechtigungen, die der Benutzer für das Ziel-Dataset erhält.
+#
+# Die Struktur des ACL-Strings folgt dem Format:
+# "rwxpDdaARWcCos:fd:allow"
+#
+# Weitere Informationen und eine detaillierte Dokumentation zu den NFSv4 ACLs
+# finden Sie auf der folgenden Webseite:
+# - https://linux.die.net/man/1/nfs4_setfacl
+# ----------------------------------------------------------------------------------------
+
+### === Dry-Run prüfen ===
+
+# Wenn das Skript mit dem Parameter --dry-run gestartet wird,
+# wird kein echter Schreibzugriff ausgeführt – nur simuliert.
+DRYRUN=false
+if [ "$1" == "--dry-run" ]; then
+    DRYRUN=true
+    echo ">>> [⏭] Dry-Run-Modus aktiviert"
+    echo ">>> [⏭] Dry-Run-Modus aktiviert" >> "$LOGFILE"
+fi
+
+### === Hilfsfunktionen ===
+
+# Gibt eine Nachricht sowohl auf der Konsole als auch im Logfile aus
+log() {
+    echo "$1"
+    echo "$1" >> "$LOGFILE"
+}
+
+# Führt einen Befehl aus oder zeigt ihn nur im Dry-Run-Modus
+run() {
+    if $DRYRUN; then
+        log "    [dry-run] $*"
+    else
+        eval "$@"
+    fi
+}
+
+# Prüft, ob ein Benutzer übersprungen werden soll
+should_skip_user() {
+    local username="$1"
+    [[ ",$SKIP_USERS," == *",$username,"* ]]
+}
+
+# Sendet das Logfile per Mail, falls MAILTO gesetzt ist
+send_report() {
+    if [ -n "$MAILTO" ]; then
+        mail -s "TrueNAS Migration Report" "$MAILTO" < "$LOGFILE"
+        log ">>> 📧 Bericht an $MAILTO gesendet."
+    fi
+}
+
+# Setzt ACLs auf einem Ziel-Dataset anhand der UID des Benutzers
+set_acl() {
+    if [ "$#" -ne 1 ]; then
+        log "   [✗] Fehler: set_acl erwartet genau 1 Parameter, aber $# erhalten!"
+        return 1
+    fi
+
+    local USERPATH="$1"
+    local USERNAME=$(basename "$USERPATH")
+
+    log "   -> Setze ACL für $USERNAME"
+
+    # Definiere den Dataset-Pfad ohne /mnt
+    local DATASET_PATH="${MAIN_POOL}/${MAIN_DATASET}/${USERNAME}"
+
+    # Der vollständige Mount-Pfad für den Dataset (inklusive /mnt)
+    local MOUNT_PATH="${MAIN_PATH}/${DATASET_PATH}"
+
+    log "   -> Überprüfe ACL für Dataset: $DATASET_PATH"
+
+    # AD-Domain und Benutzername für die UID-Auflösung
+    local FQ_USER="${AD_DOMAIN}\\${USERNAME}"
+    log "   -> Teste getent für: $FQ_USER"
+    local USER_UID=$(getent passwd "$FQ_USER" | cut -d: -f3)
+
+    if [ -z "$USER_UID" ]; then
+        log "   [✗] Konnte UID für $USERNAME ($FQ_USER) nicht auflösen"
+        return 1
+    fi
+
+    log "   [✓] UID für $USERNAME ($FQ_USER) ist: $USER_UID"
+
+    # ZFS ACL-Eigenschaften setzen, ohne /mnt
+    if ! zfs set acltype=nfsv4 "$DATASET_PATH"; then
+        log "   [✗] Fehler beim Setzen des ACL-Typs für $USERNAME auf $DATASET_PATH"
+    fi
+
+    if ! zfs set xattr=sa "$DATASET_PATH"; then
+        log "   [✗] Fehler beim Setzen von xattr=sa für $USERNAME auf $DATASET_PATH"
+    fi
+
+    if ! zfs set aclmode=passthrough "$DATASET_PATH"; then
+        log "   [✗] Fehler beim Setzen von aclmode=passthrough für $USERNAME auf $DATASET_PATH"
+    fi
+
+    # Anwenden der tatsächlichen NFSv4 ACL mit Benutzer-UID, hier wird MOUNT_PATH verwendet
+    if ! nfs4xdr_setfacl -a "user:${USER_UID}:${NFS4_ACL_STRING}" "$MOUNT_PATH"; then
+        log "   [✗] Fehler beim Setzen der NFSv4 ACL für $USERNAME (UID $USER_UID) auf $MOUNT_PATH"
+    else
+        log "   [✓] NFSv4 ACL für $USERNAME (UID $USER_UID) auf $MOUNT_PATH gesetzt."
+    fi
+}
+
+
+### === Startmeldung ===
+
+log ">>> Starte das Migrationsskript"
+log ">>> Quelle: $SOURCE_MOUNT"
+log ">>> Ziel: ${MAIN_POOL}/${MAIN_DATASET}"
+$DRYRUN && log ">>> Modus: Dry-Run (Simulation)"
+log ">>> Benutzer ausschließen: $SKIP_USERS"
+
+# Prüfen, ob das Quellverzeichnis gemountet ist
+if ! mountpoint -q "$SOURCE_MOUNT"; then
+    log "   [✗] Fehler: Quelle $SOURCE_MOUNT ist nicht gemountet. Abbruch."
+    exit 1
+fi
+
+### === Schritt 1: Haupt-Dataset prüfen/erstellen ===
+
+# Setzt die vollständigen Namen für das Root-Dataset und den Mountpfad zusammen
+ROOT_FULL="${MAIN_POOL}/${MAIN_DATASET}"
+ROOT_MOUNT="${MAIN_PATH}/${ROOT_FULL}"
+
+# Prüfen, ob das Haupt-Dataset bereits existiert – wenn nicht, wird es erstellt
+if ! zfs list "$ROOT_FULL" >/dev/null 2>&1; then
+    log "-> Erstelle Haupt-Dataset: $ROOT_FULL"
+    run zfs create "$ROOT_FULL"
+else
+    log "-> Haupt-Dataset $ROOT_FULL existiert bereits."
+fi
+
+### === Schritt 2: Benutzer-Subdatasets erstellen ===
+
+# Liste aller Unterordner im Quellverzeichnis ermitteln (Benutzerverzeichnisse)
+USER_FOLDERS=()
+for folder in "$SOURCE_MOUNT"/*; do
+    [ -d "$folder" ] && USER_FOLDERS+=("$folder")
+done
+
+# Jedes Benutzerverzeichnis verarbeiten
+for src_folder in "${USER_FOLDERS[@]}"; do
+    username=$(basename "$src_folder")
+
+    if should_skip_user "$username"; then
+        log "   [⏭] Benutzer '$username' ist in SKIP_USERS. Überspringe."
+        continue
+    fi
+
+    subdataset="${ROOT_FULL}/${username}"
+    submount="${MAIN_PATH}/${subdataset}"
+
+    log "-> Verarbeite Benutzer '$username'"
+
+    # Subdataset nur erstellen, wenn es noch nicht existiert
+    if zfs list "$subdataset" >/dev/null 2>&1; then
+        log "   [!] Subdataset $subdataset existiert bereits. Überspringe Erstellung."
+        continue
+    fi
+
+    log "   -> Erstelle Subdataset $subdataset mit Quota $QUOTA"
+    run zfs create -o quota="$QUOTA" "$subdataset"
+    log "   [✓] Subdataset für $username erstellt."
+
+    # Setzen der ACLs für das neu erstellte Dataset
+    set_acl "$submount"
+
+done
+
+log ">>> [✓] Alle Subdatasets verarbeitet."
+
+### === Schritt 3: Daten kopieren ===
+
+# Kopiert Benutzerdaten von der Quelle zum Ziel
+for src_folder in "${USER_FOLDERS[@]}"; do
+    username=$(basename "$src_folder")
+
+    if should_skip_user "$username"; then
+        continue
+    fi
+
+    dst_mount="${MAIN_PATH}/${ROOT_FULL}/${username}"
+
+    # Zielverzeichnis muss vorhanden sein
+    if [ ! -d "$dst_mount" ]; then
+        log "   [✗] Zielverzeichnis für '$username' fehlt. Überspringe Kopieren."
+        continue
+    fi
+
+    log "-> Kopiere Dateien für Benutzer '$username'"
+
+    # Tatsächlicher Kopiervorgang oder nur Anzeige im Dry-Run
+    if $DRYRUN; then
+        log "    [dry-run] rsync -a --info=progress2 '$src_folder/' '$dst_mount/'"
+    else
+        rsync -a --info=progress2 "$src_folder/" "$dst_mount/"
+        if [ $? -eq 0 ]; then
+            log "   [✓] Dateien erfolgreich kopiert für $username"
+        else
+            log "   [✗] Fehler beim Kopieren der Dateien für $username"
+        fi
+    fi
+
+done
+
+log ">>> [✓] Migration abgeschlossen."
+
+### === Schritt 4: Bericht senden (optional) ===
+
+send_report


### PR DESCRIPTION
### TrueNAS SMB to ZFS Migration Script

This script automates the process of migrating user directories from an SMB share to a ZFS pool on TrueNAS. It streamlines the process by performing essential tasks such as creating ZFS datasets with quotas, transferring data from the SMB share to ZFS using rsync, and configuring NFSv4 ACLs to ensure proper access control per user. Additionally, the script supports a dry-run mode for testing and optionally sends email reports upon completion.

This solution is tailored for administrators who need to efficiently migrate a large number of users, enforce data quotas, and ensure that proper permissions are set on the new ZFS datasets. The script works best in environments where user directories are stored in SMB shares and need to be moved to a ZFS-based storage system with strict access controls. 

### Key Features:

**User Directory Migration:** 
Automatically creates ZFS datasets for each user with configurable quotas (e.g., 1G per user).

**SMB to ZFS Data Transfer:** 
Efficiently copies user data from the SMB share to ZFS datasets using rsync, ensuring data integrity.

**NFSv4 ACL Management:** 
Configures proper NFSv4 ACLs for each user, based on their UID, to ensure correct permissions on the ZFS datasets.

**Dry-Run Mode:** 
Simulates the migration process without making any changes to the system. This allows for testing before actually migrating data.

**User Exclusion:** 
Supports a configurable list of users to exclude from the migration process (e.g., for system accounts or test users).

**Email Reports:** 
Optionally sends a detailed email report with the migration results, which is useful for keeping stakeholders informed.

### Important Notes:

Usernames and Folder Names Must Match: In the current state of the script, the usernames and the folder names inside the SMB share must match exactly. This is because the script fetches the usernames from the folder names in the SMB share. For example, if you have a user named johndoe on your SMB share, there must be a folder named johndoe in the SMB share. The script will then use this folder name (johndoe) to identify the user and migrate the corresponding data.

Configurable NFSv4 ACL String: The NFSv4 ACL string is customizable, allowing administrators to modify permissions as needed. This string determines the level of access granted to users on their respective datasets. The default string is rwxpDdaARWcCos:fd:allow, which provides full access with various options, including read, write, and execute permissions. More information on NFSv4 ACL strings can be found in the NFSv4 ACL documentation.

### Configuration:

At the beginning of the script, you can configure several variables, such as:

- MAIN_PATH: Base path for ZFS mounts (e.g., /mnt).
- MAIN_POOL: Name of the ZFS pool (e.g., tank).
- MAIN_DATASET: Main dataset name (e.g., userfiles).
- SOURCE_MOUNT: The mounted SMB share location (e.g., /mnt/oldhomes).
- QUOTA: User quota for storage (e.g., 1G per user).
- LOGFILE: Path to the log file (e.g., ./migration.log).
- MAILTO: Optional email address for sending a report upon completion.
- SKIP_USERS: A comma-separated list of users to exclude from the migration process.
- NFS4_ACL_STRING: The NFSv4 ACL string used to configure permissions for each user on their ZFS dataset. The default value is rwxpDdaARWcCos:fd:allow.

### Usage:

- Configure the script with your desired settings (e.g., paths, quotas, email).
- Run the script. For a dry-run simulation (no changes made), use the --dry-run flag.
- Monitor the script output in the terminal and check the log file for detailed progress.
- Optionally, an email report will be sent if you configure the MAILTO variable.

**Example usage:**
`./migrate_smb_to_zfs.sh`

**For a dry run:**
`./migrate_smb_to_zfs.sh --dry-run`

License: 
This script is licensed under the GNU Affero General Public License v3.0.